### PR TITLE
Update gitignore for Node/React artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
-# Local Netlify folder
-.netlify
+# Local Netlify folder used for previews
+.netlify/
+
+# Node dependencies installed via npm
+node_modules/
+
+# Compiled React build output
+build/
+
+# Environment variable definitions
+.env
+
+# Log files
+*.log

--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ npm run build
 ```
 
 The optimized files are placed in the `build/` directory. Serve this folder with your preferred static file server and ensure the backend (`node server.js`) is running to handle API calls.
+
+## Git Ignore
+
+Certain paths are excluded from version control via `.gitignore`:
+
+- `node_modules/` contains external dependencies and can be reinstalled at any time.
+- `build/` holds compiled production files.
+- `.env` stores local environment variables such as API keys.
+- `*.log` matches log output that is not needed in Git.
+
+Ignoring these keeps the repository smaller and prevents leaking sensitive information.


### PR DESCRIPTION
## Summary
- ignore common Node and React artifacts like node_modules, build, .env and log files
- document ignored paths in the README

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68443810f5f88331bf09b5c9bf246915